### PR TITLE
Feat/testing features

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -19,3 +19,23 @@ globs: tests/**/*.php
 - Run a single test: `vendor/bin/pest --filter="test name"`
 - Run a directory: `vendor/bin/pest tests/Unit/`
 - Coverage target: **90%+ lines, 80%+ branches**
+
+## Testing Assertions API
+
+For tests that verify captured emails, use the package's built-in testing utilities in `src/Testing/`:
+
+- **`InteractsWithMailbox` trait** — Add to test class (via `uses()` in Pest). Auto-clears mailbox before each test. Provides `$this->mailbox()` for assertions.
+- **`Mailbox` facade** — Supports `Mailbox::assertSent()`, `Mailbox::assertSentTo()`, `Mailbox::assertNothingSent()`, etc.
+- **`PendingMailboxMessageAssertion`** — Returned by `firstSent()`. Fluent chainable: `->assertHasSubject()->assertSeeInHtml()->assertHasAttachment()`
+- **`MailboxAssertions`** — Returned by `$this->mailbox()`. Collection-level: `assertSent()`, `assertSentCount()`, `sent()`, `firstSent()`
+
+Example pattern:
+```php
+uses(InteractsWithMailbox::class);
+
+it('sends email', function () {
+    Mail::to('user@test.com')->send(new SomeMailable);
+    Mailbox::assertSentTo('user@test.com');
+    Mailbox::firstSent()->assertHasSubject('Expected Subject')->assertSeeInHtml('expected content');
+});
+```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -88,6 +88,16 @@
 * Add **arch tests** to enforce boundaries (forbidden dependencies, env usage, etc.).
 * Target: **90%+** statement coverage; PRs below fail.
 
+### Testing Assertions API (`src/Testing/`)
+
+The package provides built-in testing helpers for verifying captured emails:
+
+* **`InteractsWithMailbox` trait** — Add via `uses()` in Pest or `use` in PHPUnit. Auto-clears mailbox before each test.
+* **`Mailbox` facade** — Supports `assertSent()`, `assertSentTo()`, `assertNothingSent()`, `assertSentCount()`, `sent()`, `firstSent()`
+* **`PendingMailboxMessageAssertion`** — Fluent per-message assertions via `firstSent()`: `assertHasSubject()`, `assertSeeInHtml()`, `assertHasTo()`, `assertHasAttachment()`, etc.
+
+When writing tests that verify email sending, prefer these helpers over manual `CaptureService::all()` boilerplate.
+
 ### Required test suites & example scenarios
 
 * **CaptureService (Unit)**

--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -4,6 +4,9 @@ on:
   push:
     paths:
       - '**.php'
+  pull_request:
+    paths:
+      - '**.php'
 
 permissions:
   contents: write

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -6,6 +6,11 @@ on:
       - '**.php'
       - 'phpstan.neon.dist'
       - '.github/workflows/phpstan.yml'
+  pull_request:
+    paths:
+      - '**.php'
+      - 'phpstan.neon.dist'
+      - '.github/workflows/phpstan.yml'
 
 jobs:
   phpstan:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,6 +8,13 @@ on:
       - 'phpunit.xml.dist'
       - 'composer.json'
       - 'composer.lock'
+  pull_request:
+    paths:
+      - '**.php'
+      - '.github/workflows/run-tests.yml'
+      - 'phpunit.xml.dist'
+      - 'composer.json'
+      - 'composer.lock'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ phpstan.neon
 testbench.yaml
 /docs
 /coverage
+.obsidian

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `mailbox-for-laravel` will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added Testing Assertions API (`src/Testing/`) for verifying captured emails in test suites
+  - `InteractsWithMailbox` trait — auto-clears mailbox between tests, provides `$this->mailbox()`
+  - `MailboxAssertions` — collection-level: `assertSent()`, `assertNotSent()`, `assertNothingSent()`, `assertSentCount()`, `assertSentTo()`, `assertNotSentTo()`, `sent()`, `firstSent()`
+  - `PendingMailboxMessageAssertion` — per-message fluent: `assertHasSubject()`, `assertSeeInHtml()`, `assertHasTo()`, `assertHasAttachment()`, and more
+  - Facade support: `Mailbox::assertSent()`, `Mailbox::assertSentTo()`, etc.
+  - Works with both Pest and PHPUnit
 - Added "Clear Inbox" functionality to delete all messages via DELETE /mailbox/messages
 - Added "Delete Single Message" functionality to delete individual messages via DELETE /mailbox/messages/{id}
 - Added AlertDialog component suite using radix-vue for confirmation dialogs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,12 +44,16 @@ src/
   Support/
     MessageNormalizer.php           # Email → canonical array + attachment extraction
     CidRewriter.php                 # Rewrites inline cid: refs to downloadable routes
+  Testing/
+    MailboxAssertions.php           # Collection-level assertions (assertSent, assertSentTo, etc.)
+    PendingMailboxMessageAssertion.php  # Per-message fluent assertions (assertHasSubject, assertSeeInHtml, etc.)
+    InteractsWithMailbox.php        # Trait for test classes — auto-clear, provides $this->mailbox()
   Http/Controllers/                 # 7 thin controllers, return Inertia or JSON responses
   Http/Middleware/                  # HandleInertiaRequests, AuthorizeMailboxMiddleware
   DTO/                              # MailboxMessageData, AttachmentData (Spatie Laravel Data)
   Models/                           # MailboxMessage, MailboxAttachment (Eloquent)
   Commands/                         # mailbox:install, mailbox:clear, mailbox:dev-link
-  Facades/Mailbox.php               # Facade for CaptureService
+  Facades/Mailbox.php               # Facade for CaptureService + assertion method proxying
 
 resources/js/
   dashboard.js                      # Isolated Inertia app entry point
@@ -95,9 +99,33 @@ Uses **Pest** with Orchestra Testbench. Base `TestCase` sets up in-memory SQLite
 tests/
 ├── Architecture/    # Arch rules (26 rules enforcing boundaries)
 ├── Commands/        # Artisan command tests
-├── Feature/         # HTTP/integration tests (9 controller/middleware tests)
-└── Unit/            # Unit tests (12 files covering all core services)
+├── Feature/         # HTTP/integration + InteractsWithMailbox tests
+└── Unit/            # Unit tests (services, storage, testing assertions)
 ```
+
+### Testing Assertions API (`src/Testing/`)
+
+The package provides Laravel-idiomatic assertion helpers for verifying captured emails in test suites. Works with both **Pest** and **PHPUnit**.
+
+**Trait:** `InteractsWithMailbox` — auto-clears mailbox between tests, provides `$this->mailbox()`.
+
+**Collection-level** (via `$this->mailbox()` or `Mailbox` facade):
+- `assertSent(Closure $callback, ?int $expectedCount = null)`
+- `assertNotSent(Closure $callback)`
+- `assertNothingSent()`
+- `assertSentCount(int $count)`
+- `assertSentTo(string $email, ?Closure $callback = null)`
+- `assertNotSentTo(string $email, ?Closure $callback = null)`
+- `sent(?Closure $callback = null): Collection` — raw query
+- `firstSent(?Closure $callback = null): PendingMailboxMessageAssertion`
+
+**Per-message fluent** (via `firstSent()`):
+- `assertFrom()`, `assertHasTo()`, `assertHasCc()`, `assertHasBcc()`, `assertHasReplyTo()`
+- `assertHasSubject()`, `assertSubjectContains()`
+- `assertSeeInHtml()`, `assertDontSeeInHtml()`, `assertSeeInText()`, `assertDontSeeInText()`
+- `assertSeeInOrderInHtml()`, `assertSeeInOrderInText()`
+- `assertHasAttachment()`, `assertHasNoAttachments()`, `assertAttachmentCount()`
+- `assertHasHeader()`
 
 ### Test Policy
 
@@ -109,6 +137,7 @@ tests/
 - Use Pest `describe()` blocks and dataset-driven test cases
 - Use named routes in HTTP tests: `route('mailbox.index')`
 - Inertia assertions: `$response->assertInertia(fn (Assert $page) => ...)`
+- Email assertions: use `InteractsWithMailbox` trait + `Mailbox::assertSent()` facade
 
 ## Coding Conventions
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Mailtrap, but self-contained within your application.
 - [Deploying on Staging / VPS / Docker](#deploying-on-staging--vps--docker)
 - [Authorization & Security](#authorization--security)
 - [Testing](#testing)
+    - [Testing Assertions API](#testing-assertions-api)
 - [Development](#development)
 - [Changelog](#changelog)
 - [Security Vulnerabilities](#security-vulnerabilities)
@@ -51,6 +52,7 @@ Mailtrap, but self-contained within your application.
 - **Responsive UI** — Beautiful TailwindCSS-based interface with dark mode support
 - **Developer-friendly** — Auto-enabled in non-production environments
 - **Test helpers** — Send test emails directly from the dashboard
+- **Testing assertions API** — Laravel-idiomatic helpers for verifying captured emails in your test suite (`assertSentTo`, `assertSeeInHtml`, etc.)
 
 ## Requirements
 
@@ -694,6 +696,158 @@ MAILBOX_REDIRECT=/login
 
 ## Testing
 
+### Testing Assertions API
+
+The package provides expressive, Laravel-idiomatic assertion helpers for verifying captured emails in your test suite. Unlike `Mail::fake()` which only checks if a Mailable was dispatched, these assertions verify the **actual rendered email** — real HTML, real recipients, real attachments.
+
+Works with both **Pest** and **PHPUnit**.
+
+#### Setup
+
+Add the `InteractsWithMailbox` trait to your test class. It automatically clears the mailbox before each test.
+
+**Pest:**
+
+```php
+use Redberry\MailboxForLaravel\Testing\InteractsWithMailbox;
+
+uses(InteractsWithMailbox::class);
+```
+
+**PHPUnit:**
+
+```php
+use Redberry\MailboxForLaravel\Testing\InteractsWithMailbox;
+
+class OrderEmailTest extends TestCase
+{
+    use InteractsWithMailbox;
+}
+```
+
+#### Collection-Level Assertions
+
+Assert against all captured emails using the trait's `$this->mailbox()` method or the `Mailbox` facade:
+
+```php
+use Redberry\MailboxForLaravel\Facades\Mailbox;
+use Redberry\MailboxForLaravel\DTO\MailboxMessageData;
+
+// Assert a specific number of emails were captured
+Mailbox::assertSentCount(2);
+
+// Assert no emails were captured
+Mailbox::assertNothingSent();
+
+// Assert an email was sent to a specific address
+Mailbox::assertSentTo('user@example.com');
+
+// Assert no email was sent to an address
+Mailbox::assertNotSentTo('admin@example.com');
+
+// Assert with a custom callback
+Mailbox::assertSent(fn (MailboxMessageData $m) => $m->subject === 'Welcome');
+
+// Assert exact count with callback
+Mailbox::assertSent(
+    fn (MailboxMessageData $m) => str_contains($m->subject, 'Newsletter'),
+    expectedCount: 3
+);
+
+// Assert with recipient + callback
+Mailbox::assertSentTo('user@example.com', fn (MailboxMessageData $m) => $m->subject === 'Welcome');
+
+// Query captured messages for custom assertions
+$messages = Mailbox::sent(fn (MailboxMessageData $m) => $m->subject === 'Reset');
+expect($messages)->toHaveCount(1);
+```
+
+#### Per-Message Fluent Assertions
+
+Use `firstSent()` to get a fluent assertion object for a captured email:
+
+```php
+Mailbox::firstSent()
+    ->assertHasSubject('Order Confirmation')
+    ->assertFrom('noreply@shop.com')
+    ->assertHasTo('buyer@example.com')
+    ->assertHasCc('accounting@shop.com')
+    ->assertSeeInHtml('Order #12345')
+    ->assertSeeInHtml('$49.99')
+    ->assertDontSeeInHtml('error')
+    ->assertSeeInText('Thank you for your purchase')
+    ->assertHasAttachment('invoice.pdf', 'application/pdf')
+    ->assertAttachmentCount(1)
+    ->assertHasHeader('X-Mailer');
+```
+
+Filter before asserting:
+
+```php
+// Get the first email matching a callback
+Mailbox::firstSent(fn (MailboxMessageData $m) => $m->subject === 'Password Reset')
+    ->assertHasTo('user@example.com')
+    ->assertSeeInHtml('Reset your password');
+```
+
+#### Available Per-Message Assertions
+
+| Method | Description |
+|---|---|
+| `assertFrom($email, $name?)` | Assert the sender email (and optionally name) |
+| `assertHasTo($email, $name?)` | Assert a "to" recipient exists |
+| `assertHasCc($email, $name?)` | Assert a "cc" recipient exists |
+| `assertHasBcc($email, $name?)` | Assert a "bcc" recipient exists |
+| `assertHasReplyTo($email, $name?)` | Assert a "reply-to" address exists |
+| `assertHasSubject($subject)` | Assert exact subject match |
+| `assertSubjectContains($substring)` | Assert subject contains a substring |
+| `assertSeeInHtml($string)` | Assert HTML body contains string |
+| `assertDontSeeInHtml($string)` | Assert HTML body does not contain string |
+| `assertSeeInText($string)` | Assert text body contains string |
+| `assertDontSeeInText($string)` | Assert text body does not contain string |
+| `assertSeeInOrderInHtml($strings)` | Assert strings appear in order in HTML |
+| `assertSeeInOrderInText($strings)` | Assert strings appear in order in text |
+| `assertHasAttachment($filename, $mimeType?)` | Assert attachment exists |
+| `assertHasNoAttachments()` | Assert no attachments |
+| `assertAttachmentCount($count)` | Assert number of attachments |
+| `assertHasHeader($name, $value?)` | Assert header exists (optionally with value) |
+
+#### Full Example
+
+```php
+use Redberry\MailboxForLaravel\Facades\Mailbox;
+use Redberry\MailboxForLaravel\Testing\InteractsWithMailbox;
+
+uses(InteractsWithMailbox::class);
+
+it('sends welcome email with getting started guide', function () {
+    // Trigger the action that sends the email
+    $this->post('/register', [
+        'name' => 'John Doe',
+        'email' => 'john@example.com',
+        'password' => 'secret123',
+    ]);
+
+    // Verify the email was captured
+    Mailbox::assertSentCount(1);
+    Mailbox::assertSentTo('john@example.com');
+
+    // Verify email content
+    Mailbox::firstSent()
+        ->assertHasSubject('Welcome, John!')
+        ->assertFrom('noreply@myapp.com')
+        ->assertSeeInHtml('Getting Started')
+        ->assertSeeInOrderInHtml(['Welcome', 'Getting Started', 'Support'])
+        ->assertHasAttachment('getting-started.pdf');
+});
+
+it('does not send email when registration fails', function () {
+    $this->post('/register', ['email' => 'invalid']);
+
+    Mailbox::assertNothingSent();
+});
+```
+
 ### Running Tests
 
 The package includes comprehensive test coverage using **Pest**.
@@ -744,36 +898,6 @@ composer format
 
 # Or directly
 ./vendor/bin/pint
-```
-
-### Writing Tests
-
-Tests follow the repository structure:
-
-```
-tests/
-├── Architecture/    # Arch tests for architectural rules
-├── Feature/         # Integration tests for controllers, commands
-└── Unit/            # Unit tests for services, transport, storage
-```
-
-**Example test:**
-
-```php
-use Redberry\MailboxForLaravel\CaptureService;
-
-it('stores a message and returns a key', function () {
-    $service = app(CaptureService::class);
-    
-    $key = $service->store([
-        'from' => 'sender@example.com',
-        'subject' => 'Test',
-        'raw' => 'Full message',
-    ]);
-    
-    expect($key)->toBeString();
-    expect($service->get($key))->toBeArray();
-});
 ```
 
 ## Development

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,5 @@
+parameters:
+    ignoreErrors:
+        -
+            message: '#Trait Redberry\\MailboxForLaravel\\Testing\\InteractsWithMailbox is used zero times and is not analysed#'
+            path: src/Testing/InteractsWithMailbox.php

--- a/src/Facades/Mailbox.php
+++ b/src/Facades/Mailbox.php
@@ -2,11 +2,65 @@
 
 namespace Redberry\MailboxForLaravel\Facades;
 
+use Closure;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Facade;
 use Redberry\MailboxForLaravel\CaptureService;
+use Redberry\MailboxForLaravel\DTO\MailboxMessageData;
+use Redberry\MailboxForLaravel\Testing\MailboxAssertions;
+use Redberry\MailboxForLaravel\Testing\PendingMailboxMessageAssertion;
 
+/**
+ * @method static string|int store(array $payload)
+ * @method static string storeRaw(string $raw)
+ * @method static array list(int $page = 1, int $perPage = 10)
+ * @method static array<int, MailboxMessageData> all()
+ * @method static MailboxMessageData|null find(string $id)
+ * @method static MailboxMessageData|null update(string $id, array $changes)
+ * @method static MailboxMessageData|null markSeen(string $id)
+ * @method static void delete(string $id)
+ * @method static void purgeOlderThan(int $seconds)
+ * @method static void clearAll()
+ * @method static void assertSent(Closure $callback, ?int $expectedCount = null)
+ * @method static void assertNotSent(Closure $callback)
+ * @method static void assertNothingSent()
+ * @method static void assertSentCount(int $count)
+ * @method static void assertSentTo(string $email, ?Closure $callback = null)
+ * @method static void assertNotSentTo(string $email, ?Closure $callback = null)
+ * @method static Collection sent(?Closure $callback = null)
+ * @method static PendingMailboxMessageAssertion firstSent(?Closure $callback = null)
+ *
+ * @see CaptureService
+ * @see MailboxAssertions
+ */
 class Mailbox extends Facade
 {
+    private static array $assertionMethods = [
+        'assertSent',
+        'assertNotSent',
+        'assertNothingSent',
+        'assertSentCount',
+        'assertSentTo',
+        'assertNotSentTo',
+        'sent',
+        'firstSent',
+    ];
+
+    /**
+     * @param  string  $method
+     * @param  array<int, mixed>  $args
+     */
+    public static function __callStatic($method, $args): mixed
+    {
+        if (in_array($method, self::$assertionMethods, true)) {
+            $assertions = new MailboxAssertions(static::getFacadeRoot());
+
+            return $assertions->{$method}(...$args);
+        }
+
+        return parent::__callStatic($method, $args);
+    }
+
     protected static function getFacadeAccessor(): string
     {
         return CaptureService::class;

--- a/src/Testing/InteractsWithMailbox.php
+++ b/src/Testing/InteractsWithMailbox.php
@@ -19,17 +19,25 @@ trait InteractsWithMailbox
     protected ?MailboxAssertions $mailboxAssertions = null;
 
     /**
-     * @before
+     * Invoked automatically by Laravel's setUpTraits() via the
+     * setUp{TraitName} convention. Registers an application-boot hook that
+     * clears the mailbox once the test application is ready.
      */
     protected function setUpInteractsWithMailbox(): void
     {
         $this->afterApplicationCreated(function (): void {
             $this->clearMailbox();
         });
+    }
 
-        $this->beforeApplicationDestroyed(function (): void {
-            $this->mailboxAssertions = null;
-        });
+    /**
+     * Invoked automatically by Laravel's setUpTraits() via the
+     * tearDown{TraitName} convention. Clears the cached assertions instance
+     * between tests so state from one test cannot leak into another.
+     */
+    protected function tearDownInteractsWithMailbox(): void
+    {
+        $this->mailboxAssertions = null;
     }
 
     /**

--- a/src/Testing/InteractsWithMailbox.php
+++ b/src/Testing/InteractsWithMailbox.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Redberry\MailboxForLaravel\Testing;
+
+use Redberry\MailboxForLaravel\CaptureService;
+
+/**
+ * Trait for test classes that need to assert against captured mailbox messages.
+ *
+ * Automatically clears the mailbox before each test for isolation.
+ * Works with both PHPUnit TestCase and Pest (via uses()).
+ *
+ * Requires a Laravel application context (Orchestra Testbench or Laravel's TestCase).
+ */
+trait InteractsWithMailbox
+{
+    protected ?MailboxAssertions $mailboxAssertions = null;
+
+    /**
+     * @before
+     */
+    protected function setUpInteractsWithMailbox(): void
+    {
+        $this->afterApplicationCreated(function (): void {
+            $this->clearMailbox();
+        });
+
+        $this->beforeApplicationDestroyed(function (): void {
+            $this->mailboxAssertions = null;
+        });
+    }
+
+    /**
+     * Clear all captured messages from the mailbox.
+     */
+    public function clearMailbox(): void
+    {
+        app(CaptureService::class)->clearAll();
+    }
+
+    /**
+     * Get the mailbox assertions instance for the current test.
+     */
+    public function mailbox(): MailboxAssertions
+    {
+        if ($this->mailboxAssertions === null) {
+            $this->mailboxAssertions = new MailboxAssertions(
+                app(CaptureService::class),
+            );
+        }
+
+        return $this->mailboxAssertions;
+    }
+}

--- a/src/Testing/MailboxAssertions.php
+++ b/src/Testing/MailboxAssertions.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Redberry\MailboxForLaravel\Testing;
+
+use Closure;
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\Assert as PHPUnit;
+use Redberry\MailboxForLaravel\CaptureService;
+use Redberry\MailboxForLaravel\DTO\MailboxMessageData;
+
+class MailboxAssertions
+{
+    public function __construct(
+        protected CaptureService $capture,
+    ) {}
+
+    /**
+     * Assert that at least one (or exactly $expectedCount) captured message(s) match the callback.
+     */
+    public function assertSent(Closure $callback, ?int $expectedCount = null): void
+    {
+        $matching = $this->sent($callback);
+
+        if ($expectedCount !== null) {
+            PHPUnit::assertCount(
+                $expectedCount,
+                $matching,
+                "Expected [{$expectedCount}] matching message(s), but [{$matching->count()}] were captured. {$this->messagesSummary()}"
+            );
+
+            return;
+        }
+
+        PHPUnit::assertTrue(
+            $matching->isNotEmpty(),
+            "No matching message was captured. {$this->messagesSummary()}"
+        );
+    }
+
+    /**
+     * Assert that no captured messages match the callback.
+     */
+    public function assertNotSent(Closure $callback): void
+    {
+        $matching = $this->sent($callback);
+
+        PHPUnit::assertTrue(
+            $matching->isEmpty(),
+            "An unexpected message was captured that matched the given callback. [{$matching->count()}] match(es) found."
+        );
+    }
+
+    /**
+     * Assert that no messages were captured at all.
+     */
+    public function assertNothingSent(): void
+    {
+        $all = $this->capture->all();
+
+        PHPUnit::assertEmpty(
+            $all,
+            'Expected no messages to be captured, but ['.count($all)."] were. {$this->messagesSummary()}"
+        );
+    }
+
+    /**
+     * Assert the total number of captured messages (without filtering).
+     */
+    public function assertSentCount(int $count): void
+    {
+        $actual = count($this->capture->all());
+
+        PHPUnit::assertSame(
+            $count,
+            $actual,
+            "Expected [{$count}] message(s) to be captured, but [{$actual}] were. {$this->messagesSummary()}"
+        );
+    }
+
+    /**
+     * Assert that at least one message was sent to the given email address.
+     */
+    public function assertSentTo(string $email, ?Closure $callback = null): void
+    {
+        $matching = $this->sentTo($email, $callback);
+
+        PHPUnit::assertTrue(
+            $matching->isNotEmpty(),
+            "No message was captured to [{$email}]. {$this->messagesSummary()}"
+        );
+    }
+
+    /**
+     * Assert that no messages were sent to the given email address.
+     */
+    public function assertNotSentTo(string $email, ?Closure $callback = null): void
+    {
+        $matching = $this->sentTo($email, $callback);
+
+        PHPUnit::assertTrue(
+            $matching->isEmpty(),
+            "An unexpected message was captured to [{$email}]. [{$matching->count()}] match(es) found."
+        );
+    }
+
+    /**
+     * Get all captured messages, optionally filtered by callback.
+     *
+     * @return Collection<int, MailboxMessageData>
+     */
+    public function sent(?Closure $callback = null): Collection
+    {
+        $messages = Collection::make($this->capture->all());
+
+        if ($callback !== null) {
+            $messages = $messages->filter(fn (MailboxMessageData $message): bool => $callback($message));
+        }
+
+        return $messages->values();
+    }
+
+    /**
+     * Get a fluent assertion object for the first matching captured message.
+     */
+    public function firstSent(?Closure $callback = null): PendingMailboxMessageAssertion
+    {
+        $messages = $this->sent($callback);
+
+        PHPUnit::assertTrue(
+            $messages->isNotEmpty(),
+            "No matching message was captured. {$this->messagesSummary()}"
+        );
+
+        return new PendingMailboxMessageAssertion($messages->first());
+    }
+
+    /**
+     * @return Collection<int, MailboxMessageData>
+     */
+    private function sentTo(string $email, ?Closure $callback = null): Collection
+    {
+        return $this->sent(function (MailboxMessageData $message) use ($email, $callback): bool {
+            $hasRecipient = $this->messageHasRecipient($message, $email);
+
+            if (! $hasRecipient) {
+                return false;
+            }
+
+            if ($callback !== null) {
+                return $callback($message);
+            }
+
+            return true;
+        });
+    }
+
+    private function messageHasRecipient(MailboxMessageData $message, string $email): bool
+    {
+        foreach ($message->to ?? [] as $recipient) {
+            if (strcasecmp($recipient['email'], $email) === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function messagesSummary(): string
+    {
+        $all = $this->capture->all();
+
+        if (count($all) === 0) {
+            return 'No messages were captured.';
+        }
+
+        $subjects = array_map(
+            static fn (MailboxMessageData $m): string => $m->subject ?? '(no subject)',
+            $all,
+        );
+
+        $recipients = [];
+        foreach ($all as $message) {
+            foreach ($message->to ?? [] as $recipient) {
+                $recipients[] = $recipient['email'];
+            }
+        }
+
+        $recipients = array_unique($recipients);
+
+        return sprintf(
+            'Captured %d message(s) with subjects: [%s], to: [%s].',
+            count($all),
+            implode(', ', $subjects),
+            implode(', ', $recipients),
+        );
+    }
+}

--- a/src/Testing/PendingMailboxMessageAssertion.php
+++ b/src/Testing/PendingMailboxMessageAssertion.php
@@ -1,0 +1,331 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Redberry\MailboxForLaravel\Testing;
+
+use PHPUnit\Framework\Assert as PHPUnit;
+use Redberry\MailboxForLaravel\DTO\MailboxMessageData;
+
+class PendingMailboxMessageAssertion
+{
+    public function __construct(
+        protected MailboxMessageData $message,
+    ) {}
+
+    public function getMessage(): MailboxMessageData
+    {
+        return $this->message;
+    }
+
+    public function assertFrom(string $email, ?string $name = null): self
+    {
+        PHPUnit::assertTrue(
+            $this->hasRecipientIn($this->message->from, $email, $name),
+            "Expected message to be from [{$email}], but it was from [{$this->formatRecipients($this->message->from)}]."
+        );
+
+        return $this;
+    }
+
+    public function assertHasTo(string $email, ?string $name = null): self
+    {
+        PHPUnit::assertTrue(
+            $this->hasRecipientIn($this->message->to, $email, $name),
+            "Expected message to have [{$email}] as a 'to' recipient, but recipients were [{$this->formatRecipients($this->message->to)}]."
+        );
+
+        return $this;
+    }
+
+    public function assertHasCc(string $email, ?string $name = null): self
+    {
+        PHPUnit::assertTrue(
+            $this->hasRecipientIn($this->message->cc, $email, $name),
+            "Expected message to have [{$email}] as a 'cc' recipient, but cc recipients were [{$this->formatRecipients($this->message->cc)}]."
+        );
+
+        return $this;
+    }
+
+    public function assertHasBcc(string $email, ?string $name = null): self
+    {
+        PHPUnit::assertTrue(
+            $this->hasRecipientIn($this->message->bcc, $email, $name),
+            "Expected message to have [{$email}] as a 'bcc' recipient, but bcc recipients were [{$this->formatRecipients($this->message->bcc)}]."
+        );
+
+        return $this;
+    }
+
+    public function assertHasReplyTo(string $email, ?string $name = null): self
+    {
+        PHPUnit::assertTrue(
+            $this->hasRecipientIn($this->message->reply_to, $email, $name),
+            "Expected message to have [{$email}] as a 'reply-to' address, but reply-to addresses were [{$this->formatRecipients($this->message->reply_to)}]."
+        );
+
+        return $this;
+    }
+
+    public function assertHasSubject(string $subject): self
+    {
+        PHPUnit::assertSame(
+            $subject,
+            $this->message->subject,
+            "Expected message subject to be [{$subject}], but got [{$this->message->subject}]."
+        );
+
+        return $this;
+    }
+
+    public function assertSubjectContains(string $substring): self
+    {
+        PHPUnit::assertNotNull($this->message->subject, 'Expected message to have a subject, but subject was null.');
+
+        PHPUnit::assertStringContainsString(
+            $substring,
+            $this->message->subject,
+            "Expected message subject to contain [{$substring}], but subject was [{$this->message->subject}]."
+        );
+
+        return $this;
+    }
+
+    public function assertSeeInHtml(string $string): self
+    {
+        PHPUnit::assertNotNull($this->message->html, 'Expected message to have an HTML body, but it was null.');
+
+        PHPUnit::assertStringContainsString(
+            $string,
+            $this->message->html,
+            "Expected to see [{$string}] in the HTML body, but it was not found."
+        );
+
+        return $this;
+    }
+
+    public function assertDontSeeInHtml(string $string): self
+    {
+        if ($this->message->html === null) {
+            return $this;
+        }
+
+        PHPUnit::assertStringNotContainsString(
+            $string,
+            $this->message->html,
+            "Unexpected [{$string}] was found in the HTML body."
+        );
+
+        return $this;
+    }
+
+    public function assertSeeInText(string $string): self
+    {
+        PHPUnit::assertNotNull($this->message->text, 'Expected message to have a text body, but it was null.');
+
+        PHPUnit::assertStringContainsString(
+            $string,
+            $this->message->text,
+            "Expected to see [{$string}] in the text body, but it was not found."
+        );
+
+        return $this;
+    }
+
+    public function assertDontSeeInText(string $string): self
+    {
+        if ($this->message->text === null) {
+            return $this;
+        }
+
+        PHPUnit::assertStringNotContainsString(
+            $string,
+            $this->message->text,
+            "Unexpected [{$string}] was found in the text body."
+        );
+
+        return $this;
+    }
+
+    /**
+     * @param  array<int, string>  $strings
+     */
+    public function assertSeeInOrderInHtml(array $strings): self
+    {
+        PHPUnit::assertNotNull($this->message->html, 'Expected message to have an HTML body, but it was null.');
+
+        $this->assertStringsInOrder($this->message->html, $strings, 'HTML');
+
+        return $this;
+    }
+
+    /**
+     * @param  array<int, string>  $strings
+     */
+    public function assertSeeInOrderInText(array $strings): self
+    {
+        PHPUnit::assertNotNull($this->message->text, 'Expected message to have a text body, but it was null.');
+
+        $this->assertStringsInOrder($this->message->text, $strings, 'text');
+
+        return $this;
+    }
+
+    public function assertHasAttachment(string $filename, ?string $mimeType = null): self
+    {
+        $attachments = $this->message->attachments ?? [];
+
+        $found = false;
+
+        foreach ($attachments as $attachment) {
+            $attachmentFilename = $attachment['filename'] ?? null;
+
+            if ($attachmentFilename !== $filename) {
+                continue;
+            }
+
+            if ($mimeType !== null) {
+                $attachmentMimeType = $attachment['contentType'] ?? $attachment['mimeType'] ?? null;
+
+                if ($attachmentMimeType === null) {
+                    continue;
+                }
+
+                // Strip parameters (e.g., "text/plain; charset=utf-8" → "text/plain")
+                $attachmentMimeType = explode(';', $attachmentMimeType)[0];
+
+                if (strcasecmp($attachmentMimeType, $mimeType) !== 0) {
+                    continue;
+                }
+            }
+
+            $found = true;
+
+            break;
+        }
+
+        PHPUnit::assertTrue(
+            $found,
+            "Expected attachment [{$filename}]".($mimeType ? " with type [{$mimeType}]" : '').' was not found on the message.'
+        );
+
+        return $this;
+    }
+
+    public function assertHasNoAttachments(): self
+    {
+        $count = count($this->message->attachments ?? []);
+
+        PHPUnit::assertSame(
+            0,
+            $count,
+            "Expected message to have no attachments, but found [{$count}]."
+        );
+
+        return $this;
+    }
+
+    public function assertAttachmentCount(int $count): self
+    {
+        $actual = count($this->message->attachments ?? []);
+
+        PHPUnit::assertSame(
+            $count,
+            $actual,
+            "Expected message to have [{$count}] attachment(s), but found [{$actual}]."
+        );
+
+        return $this;
+    }
+
+    public function assertHasHeader(string $name, ?string $value = null): self
+    {
+        $headers = $this->message->headers ?? [];
+
+        PHPUnit::assertArrayHasKey(
+            $name,
+            $headers,
+            "Expected message to have header [{$name}], but it was not found."
+        );
+
+        if ($value !== null) {
+            $headerValue = $headers[$name];
+
+            // Headers can be stored as arrays of values
+            if (is_array($headerValue)) {
+                PHPUnit::assertContains(
+                    $value,
+                    $headerValue,
+                    "Expected header [{$name}] to contain value [{$value}]."
+                );
+            } else {
+                PHPUnit::assertSame(
+                    $value,
+                    $headerValue,
+                    "Expected header [{$name}] to be [{$value}], but got [{$headerValue}]."
+                );
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param  array<int, array{email:string, name?:string}>|null  $recipients
+     */
+    private function hasRecipientIn(?array $recipients, string $email, ?string $name): bool
+    {
+        if ($recipients === null) {
+            return false;
+        }
+
+        foreach ($recipients as $recipient) {
+            if (strcasecmp($recipient['email'], $email) !== 0) {
+                continue;
+            }
+
+            if ($name !== null && ($recipient['name'] ?? '') !== $name) {
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array<int, array{email:string, name?:string}>|null  $recipients
+     */
+    private function formatRecipients(?array $recipients): string
+    {
+        if ($recipients === null || count($recipients) === 0) {
+            return '(none)';
+        }
+
+        return implode(', ', array_map(
+            static fn (array $r): string => $r['email'],
+            $recipients,
+        ));
+    }
+
+    /**
+     * @param  array<int, string>  $strings
+     */
+    private function assertStringsInOrder(string $content, array $strings, string $bodyType): void
+    {
+        $position = 0;
+
+        foreach ($strings as $index => $string) {
+            $found = strpos($content, $string, $position);
+
+            PHPUnit::assertNotFalse(
+                $found,
+                "Expected to see [{$string}] at position [{$index}] in the {$bodyType} body, but it was not found after position [{$position}]."
+            );
+
+            $position = $found + strlen($string);
+        }
+    }
+}

--- a/tests/Feature/InteractsWithMailboxTest.php
+++ b/tests/Feature/InteractsWithMailboxTest.php
@@ -1,0 +1,173 @@
+<?php
+
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Support\Facades\Mail;
+use Redberry\MailboxForLaravel\CaptureService;
+use Redberry\MailboxForLaravel\DTO\MailboxMessageData;
+use Redberry\MailboxForLaravel\Facades\Mailbox;
+use Redberry\MailboxForLaravel\Testing\InteractsWithMailbox;
+use Redberry\MailboxForLaravel\Testing\MailboxAssertions;
+use Redberry\MailboxForLaravel\Testing\PendingMailboxMessageAssertion;
+
+uses(InteractsWithMailbox::class);
+
+class TestMailable extends Mailable
+{
+    public function __construct(
+        public string $greeting = 'Hello World',
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Test Email',
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            htmlString: "<html><body><h1>{$this->greeting}</h1><p>This is a test email.</p></body></html>",
+        );
+    }
+}
+
+describe('InteractsWithMailbox trait', function () {
+    it('starts with empty mailbox', function () {
+        $this->mailbox()->assertNothingSent();
+    });
+
+    it('returns MailboxAssertions instance', function () {
+        expect($this->mailbox())->toBeInstanceOf(MailboxAssertions::class);
+    });
+
+    it('caches the assertions instance', function () {
+        $first = $this->mailbox();
+        $second = $this->mailbox();
+
+        expect($first)->toBe($second);
+    });
+
+    it('can clear mailbox manually', function () {
+        app(CaptureService::class)->store(['subject' => 'Test']);
+
+        $this->clearMailbox();
+
+        $this->mailbox()->assertNothingSent();
+    });
+});
+
+describe('InteractsWithMailbox with real emails', function () {
+    it('captures sent email and asserts count', function () {
+        Mail::to('user@test.com')->send(new TestMailable);
+
+        $this->mailbox()->assertSentCount(1);
+    });
+
+    it('asserts sent to specific recipient', function () {
+        Mail::to('user@test.com')->send(new TestMailable);
+
+        $this->mailbox()->assertSentTo('user@test.com');
+    });
+
+    it('asserts not sent to another recipient', function () {
+        Mail::to('user@test.com')->send(new TestMailable);
+
+        $this->mailbox()->assertNotSentTo('other@test.com');
+    });
+
+    it('asserts message content via firstSent', function () {
+        Mail::to('user@test.com')->send(new TestMailable('Welcome!'));
+
+        $this->mailbox()->firstSent()
+            ->assertHasSubject('Test Email')
+            ->assertHasTo('user@test.com')
+            ->assertSeeInHtml('Welcome!')
+            ->assertSeeInHtml('This is a test email.');
+    });
+
+    it('filters messages with assertSent callback', function () {
+        Mail::to('user@test.com')->send(new TestMailable('First'));
+        Mail::to('other@test.com')->send(new TestMailable('Second'));
+
+        $this->mailbox()->assertSentCount(2);
+        $this->mailbox()->assertSent(
+            fn (MailboxMessageData $m) => $m->subject === 'Test Email',
+            expectedCount: 2
+        );
+    });
+
+    it('isolates tests - mailbox is cleared between tests', function () {
+        // This test runs after previous ones that sent emails.
+        // If isolation works, the mailbox should be empty.
+        $this->mailbox()->assertNothingSent();
+
+        // Send one email
+        Mail::to('isolated@test.com')->send(new TestMailable);
+
+        $this->mailbox()->assertSentCount(1);
+    });
+});
+
+describe('Mailbox facade assertions', function () {
+    it('supports assertNothingSent on facade', function () {
+        Mailbox::assertNothingSent();
+    });
+
+    it('supports assertSentCount on facade', function () {
+        Mail::to('user@test.com')->send(new TestMailable);
+
+        Mailbox::assertSentCount(1);
+    });
+
+    it('supports assertSentTo on facade', function () {
+        Mail::to('user@test.com')->send(new TestMailable);
+
+        Mailbox::assertSentTo('user@test.com');
+    });
+
+    it('supports assertNotSentTo on facade', function () {
+        Mail::to('user@test.com')->send(new TestMailable);
+
+        Mailbox::assertNotSentTo('other@test.com');
+    });
+
+    it('supports assertSent with callback on facade', function () {
+        Mail::to('user@test.com')->send(new TestMailable);
+
+        Mailbox::assertSent(fn (MailboxMessageData $m) => $m->subject === 'Test Email');
+    });
+
+    it('supports assertNotSent on facade', function () {
+        Mail::to('user@test.com')->send(new TestMailable);
+
+        Mailbox::assertNotSent(fn (MailboxMessageData $m) => $m->subject === 'Non-existent');
+    });
+
+    it('supports sent() query on facade', function () {
+        Mail::to('user@test.com')->send(new TestMailable);
+
+        $messages = Mailbox::sent();
+
+        expect($messages)->toHaveCount(1);
+        expect($messages->first())->toBeInstanceOf(MailboxMessageData::class);
+    });
+
+    it('supports firstSent() on facade', function () {
+        Mail::to('user@test.com')->send(new TestMailable);
+
+        $assertion = Mailbox::firstSent();
+
+        expect($assertion)->toBeInstanceOf(PendingMailboxMessageAssertion::class);
+        $assertion->assertHasSubject('Test Email');
+    });
+
+    it('still proxies normal CaptureService methods', function () {
+        $all = Mailbox::all();
+
+        expect($all)->toBeArray();
+        expect($all)->toBeEmpty();
+    });
+});

--- a/tests/Unit/Testing/MailboxAssertionsTest.php
+++ b/tests/Unit/Testing/MailboxAssertionsTest.php
@@ -1,0 +1,245 @@
+<?php
+
+use PHPUnit\Framework\AssertionFailedError;
+use Redberry\MailboxForLaravel\CaptureService;
+use Redberry\MailboxForLaravel\DTO\MailboxMessageData;
+use Redberry\MailboxForLaravel\Storage\FileStorage;
+use Redberry\MailboxForLaravel\Testing\MailboxAssertions;
+use Redberry\MailboxForLaravel\Testing\PendingMailboxMessageAssertion;
+
+function assertions(): MailboxAssertions
+{
+    $path = sys_get_temp_dir().'/mailbox-assertions-tests-'.uniqid();
+    $store = new FileStorage($path);
+    $capture = new CaptureService($store);
+
+    return new MailboxAssertions($capture);
+}
+
+function assertionsWithMessages(array $messages): MailboxAssertions
+{
+    $path = sys_get_temp_dir().'/mailbox-assertions-tests-'.uniqid();
+    $store = new FileStorage($path);
+    $capture = new CaptureService($store);
+
+    foreach ($messages as $message) {
+        $capture->store($message);
+    }
+
+    return new MailboxAssertions($capture);
+}
+
+describe(MailboxAssertions::class, function () {
+    describe('assertNothingSent', function () {
+        it('passes when no messages captured', function () {
+            assertions()->assertNothingSent();
+        });
+
+        it('fails when messages exist', function () {
+            assertionsWithMessages([
+                ['subject' => 'Hello', 'to' => [['email' => 'user@test.com']]],
+            ])->assertNothingSent();
+        })->throws(AssertionFailedError::class);
+    });
+
+    describe('assertSentCount', function () {
+        it('passes when count matches', function () {
+            assertionsWithMessages([
+                ['subject' => 'One'],
+                ['subject' => 'Two'],
+            ])->assertSentCount(2);
+        });
+
+        it('fails when count does not match', function () {
+            assertionsWithMessages([
+                ['subject' => 'One'],
+            ])->assertSentCount(5);
+        })->throws(AssertionFailedError::class);
+
+        it('passes for zero when empty', function () {
+            assertions()->assertSentCount(0);
+        });
+    });
+
+    describe('assertSent', function () {
+        it('passes when callback matches a message', function () {
+            assertionsWithMessages([
+                ['subject' => 'Welcome', 'to' => [['email' => 'user@test.com']]],
+            ])->assertSent(fn (MailboxMessageData $m) => $m->subject === 'Welcome');
+        });
+
+        it('fails when no messages match callback', function () {
+            assertionsWithMessages([
+                ['subject' => 'Welcome'],
+            ])->assertSent(fn (MailboxMessageData $m) => $m->subject === 'Goodbye');
+        })->throws(AssertionFailedError::class);
+
+        it('passes when exact count matches', function () {
+            assertionsWithMessages([
+                ['subject' => 'Newsletter', 'timestamp' => 1000],
+                ['subject' => 'Newsletter', 'timestamp' => 2000],
+                ['subject' => 'Other'],
+            ])->assertSent(
+                fn (MailboxMessageData $m) => $m->subject === 'Newsletter',
+                expectedCount: 2
+            );
+        });
+
+        it('fails when count does not match', function () {
+            assertionsWithMessages([
+                ['subject' => 'Newsletter'],
+            ])->assertSent(
+                fn (MailboxMessageData $m) => $m->subject === 'Newsletter',
+                expectedCount: 3
+            );
+        })->throws(AssertionFailedError::class);
+
+        it('fails when no messages captured', function () {
+            assertions()->assertSent(fn (MailboxMessageData $m) => true);
+        })->throws(AssertionFailedError::class);
+    });
+
+    describe('assertNotSent', function () {
+        it('passes when no messages match', function () {
+            assertionsWithMessages([
+                ['subject' => 'Welcome'],
+            ])->assertNotSent(fn (MailboxMessageData $m) => $m->subject === 'Goodbye');
+        });
+
+        it('passes when no messages exist', function () {
+            assertions()->assertNotSent(fn (MailboxMessageData $m) => true);
+        });
+
+        it('fails when a message matches', function () {
+            assertionsWithMessages([
+                ['subject' => 'Welcome'],
+            ])->assertNotSent(fn (MailboxMessageData $m) => $m->subject === 'Welcome');
+        })->throws(AssertionFailedError::class);
+    });
+
+    describe('assertSentTo', function () {
+        it('passes when message sent to email', function () {
+            assertionsWithMessages([
+                ['subject' => 'Hello', 'to' => [['email' => 'user@test.com']]],
+            ])->assertSentTo('user@test.com');
+        });
+
+        it('is case-insensitive', function () {
+            assertionsWithMessages([
+                ['subject' => 'Hello', 'to' => [['email' => 'User@Test.com']]],
+            ])->assertSentTo('user@test.com');
+        });
+
+        it('passes with additional callback', function () {
+            assertionsWithMessages([
+                ['subject' => 'Welcome', 'to' => [['email' => 'user@test.com']]],
+                ['subject' => 'Reset', 'to' => [['email' => 'user@test.com']]],
+            ])->assertSentTo('user@test.com', fn (MailboxMessageData $m) => $m->subject === 'Welcome');
+        });
+
+        it('fails when no message sent to email', function () {
+            assertionsWithMessages([
+                ['subject' => 'Hello', 'to' => [['email' => 'other@test.com']]],
+            ])->assertSentTo('user@test.com');
+        })->throws(AssertionFailedError::class);
+
+        it('fails when callback does not match', function () {
+            assertionsWithMessages([
+                ['subject' => 'Hello', 'to' => [['email' => 'user@test.com']]],
+            ])->assertSentTo('user@test.com', fn (MailboxMessageData $m) => $m->subject === 'Goodbye');
+        })->throws(AssertionFailedError::class);
+    });
+
+    describe('assertNotSentTo', function () {
+        it('passes when no message sent to email', function () {
+            assertionsWithMessages([
+                ['subject' => 'Hello', 'to' => [['email' => 'other@test.com']]],
+            ])->assertNotSentTo('user@test.com');
+        });
+
+        it('fails when message sent to email', function () {
+            assertionsWithMessages([
+                ['subject' => 'Hello', 'to' => [['email' => 'user@test.com']]],
+            ])->assertNotSentTo('user@test.com');
+        })->throws(AssertionFailedError::class);
+    });
+
+    describe('sent', function () {
+        it('returns all messages without callback', function () {
+            $a = assertionsWithMessages([
+                ['subject' => 'One', 'timestamp' => 1000],
+                ['subject' => 'Two', 'timestamp' => 2000],
+            ]);
+
+            $result = $a->sent();
+
+            expect($result)->toHaveCount(2);
+            expect($result->first())->toBeInstanceOf(MailboxMessageData::class);
+        });
+
+        it('returns filtered messages with callback', function () {
+            $a = assertionsWithMessages([
+                ['subject' => 'Newsletter', 'timestamp' => 1000],
+                ['subject' => 'Welcome', 'timestamp' => 2000],
+                ['subject' => 'Newsletter', 'timestamp' => 3000],
+            ]);
+
+            $result = $a->sent(fn (MailboxMessageData $m) => $m->subject === 'Newsletter');
+
+            expect($result)->toHaveCount(2);
+        });
+
+        it('returns empty collection when no messages', function () {
+            $result = assertions()->sent();
+
+            expect($result)->toBeEmpty();
+        });
+    });
+
+    describe('firstSent', function () {
+        it('returns PendingMailboxMessageAssertion for first message', function () {
+            $a = assertionsWithMessages([
+                ['subject' => 'First', 'timestamp' => 2000],
+                ['subject' => 'Second', 'timestamp' => 1000],
+            ]);
+
+            $result = $a->firstSent();
+
+            expect($result)->toBeInstanceOf(PendingMailboxMessageAssertion::class);
+            expect($result->getMessage()->subject)->toBe('First');
+        });
+
+        it('returns first matching when callback provided', function () {
+            $a = assertionsWithMessages([
+                ['subject' => 'Other', 'timestamp' => 3000],
+                ['subject' => 'Target', 'timestamp' => 2000],
+                ['subject' => 'Target', 'timestamp' => 1000],
+            ]);
+
+            $result = $a->firstSent(fn (MailboxMessageData $m) => $m->subject === 'Target');
+
+            expect($result->getMessage()->subject)->toBe('Target');
+        });
+
+        it('fails when no messages match', function () {
+            assertions()->firstSent();
+        })->throws(AssertionFailedError::class);
+
+        it('allows chaining per-message assertions', function () {
+            $a = assertionsWithMessages([
+                [
+                    'subject' => 'Welcome',
+                    'from' => [['email' => 'app@test.com']],
+                    'to' => [['email' => 'user@test.com']],
+                    'html' => '<p>Hello World</p>',
+                ],
+            ]);
+
+            $a->firstSent()
+                ->assertHasSubject('Welcome')
+                ->assertFrom('app@test.com')
+                ->assertHasTo('user@test.com')
+                ->assertSeeInHtml('Hello World');
+        });
+    });
+});

--- a/tests/Unit/Testing/PendingMailboxMessageAssertionTest.php
+++ b/tests/Unit/Testing/PendingMailboxMessageAssertionTest.php
@@ -1,0 +1,258 @@
+<?php
+
+use PHPUnit\Framework\AssertionFailedError;
+use Redberry\MailboxForLaravel\DTO\MailboxMessageData;
+use Redberry\MailboxForLaravel\Testing\PendingMailboxMessageAssertion;
+
+function messageAssertion(array $overrides = []): PendingMailboxMessageAssertion
+{
+    $defaults = [
+        'id' => 'test-1',
+        'subject' => 'Welcome to Our App',
+        'from' => [['email' => 'noreply@app.com', 'name' => 'App']],
+        'to' => [['email' => 'user@example.com', 'name' => 'John Doe']],
+        'cc' => [['email' => 'cc@example.com']],
+        'bcc' => [['email' => 'bcc@example.com']],
+        'reply_to' => [['email' => 'support@app.com']],
+        'html' => '<h1>Welcome</h1><p>Hello John, welcome to our platform!</p>',
+        'text' => 'Welcome! Hello John, welcome to our platform!',
+        'headers' => [
+            'MIME-Version' => ['1.0'],
+            'X-Custom' => ['custom-value'],
+        ],
+        'attachments' => [
+            ['filename' => 'guide.pdf', 'contentType' => 'application/pdf', 'size' => 1024],
+            ['filename' => 'logo.png', 'contentType' => 'image/png; charset=binary', 'size' => 512, 'contentId' => 'logo123', 'inline' => true],
+        ],
+    ];
+
+    return new PendingMailboxMessageAssertion(
+        MailboxMessageData::from(array_merge($defaults, $overrides)),
+    );
+}
+
+describe(PendingMailboxMessageAssertion::class, function () {
+    describe('recipient assertions', function () {
+        it('asserts from email', function () {
+            messageAssertion()->assertFrom('noreply@app.com');
+        });
+
+        it('asserts from email with name', function () {
+            messageAssertion()->assertFrom('noreply@app.com', 'App');
+        });
+
+        it('asserts from is case-insensitive', function () {
+            messageAssertion()->assertFrom('NoReply@App.com');
+        });
+
+        it('fails when from email does not match', function () {
+            messageAssertion()->assertFrom('wrong@app.com');
+        })->throws(AssertionFailedError::class);
+
+        it('asserts has to recipient', function () {
+            messageAssertion()->assertHasTo('user@example.com');
+        });
+
+        it('asserts has to with name', function () {
+            messageAssertion()->assertHasTo('user@example.com', 'John Doe');
+        });
+
+        it('fails when to recipient name does not match', function () {
+            messageAssertion()->assertHasTo('user@example.com', 'Wrong Name');
+        })->throws(AssertionFailedError::class);
+
+        it('asserts has cc recipient', function () {
+            messageAssertion()->assertHasCc('cc@example.com');
+        });
+
+        it('fails when cc recipient does not exist', function () {
+            messageAssertion()->assertHasCc('not-cc@example.com');
+        })->throws(AssertionFailedError::class);
+
+        it('asserts has bcc recipient', function () {
+            messageAssertion()->assertHasBcc('bcc@example.com');
+        });
+
+        it('asserts has reply-to', function () {
+            messageAssertion()->assertHasReplyTo('support@app.com');
+        });
+
+        it('fails when recipients are null', function () {
+            messageAssertion(['to' => null])->assertHasTo('user@example.com');
+        })->throws(AssertionFailedError::class);
+    });
+
+    describe('subject assertions', function () {
+        it('asserts exact subject', function () {
+            messageAssertion()->assertHasSubject('Welcome to Our App');
+        });
+
+        it('fails on subject mismatch', function () {
+            messageAssertion()->assertHasSubject('Wrong Subject');
+        })->throws(AssertionFailedError::class);
+
+        it('asserts subject contains substring', function () {
+            messageAssertion()->assertSubjectContains('Welcome');
+        });
+
+        it('fails when subject does not contain substring', function () {
+            messageAssertion()->assertSubjectContains('Goodbye');
+        })->throws(AssertionFailedError::class);
+
+        it('fails when subject is null and assertSubjectContains called', function () {
+            messageAssertion(['subject' => null])->assertSubjectContains('anything');
+        })->throws(AssertionFailedError::class);
+    });
+
+    describe('html body assertions', function () {
+        it('asserts see in html', function () {
+            messageAssertion()->assertSeeInHtml('<h1>Welcome</h1>');
+        });
+
+        it('fails when string not in html', function () {
+            messageAssertion()->assertSeeInHtml('Not Present');
+        })->throws(AssertionFailedError::class);
+
+        it('asserts dont see in html', function () {
+            messageAssertion()->assertDontSeeInHtml('Not Present');
+        });
+
+        it('fails when unexpected string in html', function () {
+            messageAssertion()->assertDontSeeInHtml('Welcome');
+        })->throws(AssertionFailedError::class);
+
+        it('passes dont see in html when html is null', function () {
+            $result = messageAssertion(['html' => null])->assertDontSeeInHtml('anything');
+
+            expect($result)->toBeInstanceOf(PendingMailboxMessageAssertion::class);
+        });
+
+        it('fails see in html when html is null', function () {
+            messageAssertion(['html' => null])->assertSeeInHtml('anything');
+        })->throws(AssertionFailedError::class);
+
+        it('asserts see in order in html', function () {
+            messageAssertion()->assertSeeInOrderInHtml(['<h1>Welcome</h1>', 'Hello John']);
+        });
+
+        it('fails when order is wrong in html', function () {
+            messageAssertion()->assertSeeInOrderInHtml(['Hello John', '<h1>Welcome</h1>']);
+        })->throws(AssertionFailedError::class);
+    });
+
+    describe('text body assertions', function () {
+        it('asserts see in text', function () {
+            messageAssertion()->assertSeeInText('Hello John');
+        });
+
+        it('fails when string not in text', function () {
+            messageAssertion()->assertSeeInText('Not Present');
+        })->throws(AssertionFailedError::class);
+
+        it('asserts dont see in text', function () {
+            messageAssertion()->assertDontSeeInText('Not Present');
+        });
+
+        it('passes dont see in text when text is null', function () {
+            $result = messageAssertion(['text' => null])->assertDontSeeInText('anything');
+
+            expect($result)->toBeInstanceOf(PendingMailboxMessageAssertion::class);
+        });
+
+        it('asserts see in order in text', function () {
+            messageAssertion()->assertSeeInOrderInText(['Welcome!', 'Hello John']);
+        });
+    });
+
+    describe('attachment assertions', function () {
+        it('asserts has attachment by filename', function () {
+            messageAssertion()->assertHasAttachment('guide.pdf');
+        });
+
+        it('asserts has attachment by filename and mime type', function () {
+            messageAssertion()->assertHasAttachment('guide.pdf', 'application/pdf');
+        });
+
+        it('strips mime type parameters when matching', function () {
+            messageAssertion()->assertHasAttachment('logo.png', 'image/png');
+        });
+
+        it('fails when attachment not found', function () {
+            messageAssertion()->assertHasAttachment('missing.pdf');
+        })->throws(AssertionFailedError::class);
+
+        it('fails when mime type does not match', function () {
+            messageAssertion()->assertHasAttachment('guide.pdf', 'image/png');
+        })->throws(AssertionFailedError::class);
+
+        it('asserts has no attachments', function () {
+            messageAssertion(['attachments' => []])->assertHasNoAttachments();
+        });
+
+        it('asserts has no attachments when null', function () {
+            messageAssertion(['attachments' => null])->assertHasNoAttachments();
+        });
+
+        it('fails has no attachments when attachments exist', function () {
+            messageAssertion()->assertHasNoAttachments();
+        })->throws(AssertionFailedError::class);
+
+        it('asserts attachment count', function () {
+            messageAssertion()->assertAttachmentCount(2);
+        });
+
+        it('fails when attachment count does not match', function () {
+            messageAssertion()->assertAttachmentCount(5);
+        })->throws(AssertionFailedError::class);
+
+        it('handles mimeType key as fallback for contentType', function () {
+            $assertion = messageAssertion([
+                'attachments' => [
+                    ['filename' => 'doc.txt', 'mimeType' => 'text/plain', 'size' => 100],
+                ],
+            ]);
+
+            $assertion->assertHasAttachment('doc.txt', 'text/plain');
+        });
+    });
+
+    describe('header assertions', function () {
+        it('asserts has header by name', function () {
+            messageAssertion()->assertHasHeader('MIME-Version');
+        });
+
+        it('asserts has header with value', function () {
+            messageAssertion()->assertHasHeader('MIME-Version', '1.0');
+        });
+
+        it('fails when header not found', function () {
+            messageAssertion()->assertHasHeader('X-Missing');
+        })->throws(AssertionFailedError::class);
+
+        it('fails when header value does not match', function () {
+            messageAssertion()->assertHasHeader('MIME-Version', '2.0');
+        })->throws(AssertionFailedError::class);
+    });
+
+    describe('chaining', function () {
+        it('supports fluent chaining', function () {
+            $result = messageAssertion()
+                ->assertFrom('noreply@app.com')
+                ->assertHasTo('user@example.com')
+                ->assertHasSubject('Welcome to Our App')
+                ->assertSeeInHtml('Welcome')
+                ->assertSeeInText('Hello John')
+                ->assertHasAttachment('guide.pdf')
+                ->assertAttachmentCount(2);
+
+            expect($result)->toBeInstanceOf(PendingMailboxMessageAssertion::class);
+        });
+
+        it('exposes the underlying message via getMessage', function () {
+            $assertion = messageAssertion();
+
+            expect($assertion->getMessage())->toBeInstanceOf(MailboxMessageData::class);
+            expect($assertion->getMessage()->id)->toBe('test-1');
+        });
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,9 +8,9 @@
         "strict": true,
         "skipLibCheck": true,
 
-        "baseUrl": ".",
         "paths": {
-            "@/*": ["./resources/js/*"]
+            "@/*": ["./resources/js/*"],
+            "*": ["./*"]
         },
 
         "types": ["vite/client"]


### PR DESCRIPTION
This pull request introduces a comprehensive Testing Assertions API for verifying captured emails in test suites, making it easier and more expressive to assert on actual delivered email content and metadata. The changes add new assertion classes, update documentation throughout the project, and enhance the `Mailbox` facade to proxy assertion methods, supporting both Pest and PHPUnit. This provides Laravel-idiomatic helpers for collection-level and per-message assertions, improving test readability and reliability.

**Key changes:**

**1. New Testing Assertions API Implementation**
- Introduced `src/Testing/InteractsWithMailbox.php` trait for test classes, which auto-clears the mailbox before each test and provides a `$this->mailbox()` assertion helper.
- Added `MailboxAssertions` and `PendingMailboxMessageAssertion` classes for expressive collection-level and per-message assertions on captured emails.

**2. Facade Enhancement**
- Updated `src/Facades/Mailbox.php` to proxy assertion methods (`assertSent`, `assertSentTo`, `assertNothingSent`, etc.) to the new assertion classes, enabling a fluent and consistent API for email assertions.

**3. Documentation and Usage Examples**
- Added detailed documentation for the Testing Assertions API in `README.md`, including setup instructions, usage patterns, available assertion methods, and full code examples for both Pest and PHPUnit.
- Updated `.claude/rules/testing.md`, `.github/copilot-instructions.md`, and `CLAUDE.md` with guidance and examples for using the new assertions in tests. [[1]](diffhunk://#diff-24d4a09caff14e71d8351ac1565227601338736b6d874d920b868cf14d3ba939R22-R41) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R91-R100) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L98-R129) [[4]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R140)

**4. Changelog and Project Structure**
- Documented the new Testing Assertions API in `CHANGELOG.md` under the "Added" section.
- Updated project structure documentation in `CLAUDE.md` to reflect the new `Testing/` directory and assertion classes. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R47-R56) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L98-R129)

**5. Miscellaneous**
- Added a PHPStan baseline ignore rule for the new trait to prevent static analysis errors.
- Improved test documentation and removed outdated example test code in `README.md`.

These changes significantly improve the developer experience for testing email delivery and content, making tests more robust and maintainable.