### PR TITLE
fix: use FQCN for Vite facade in dashboard Blade view

### DIFF
--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -6,8 +6,8 @@
     <meta name="csrf-token" content="{{ $data['csrfToken'] ?? csrf_token() }}">
     <title>{{ $data['title'] ?? 'Mailbox for Laravel' }}</title>
 
-    {{ Vite::useHotFile('vendor/mailbox/mailbox.hot')
-        ->useBuildDirectory("vendor/mailbox")
+    {{ \Illuminate\Support\Facades\Vite::useHotFile('vendor/mailbox/mailbox.hot')
+        ->useBuildDirectory('vendor/mailbox')
         ->withEntryPoints(['resources/js/dashboard.js']) }}
 </head>
 <body>


### PR DESCRIPTION
This pull request makes a minor update to how the `Vite` facade is referenced in the `app.blade.php` view. The change ensures the `Vite` class is accessed via its fully qualified namespace, which can help avoid ambiguity and improve code clarity.

- Updated the reference to the `Vite` facade in `app.blade.php` to use the fully qualified namespace `\Illuminate\Support\Facades\Vite` instead of the class alias.