### PR TITLE
feat: add Laravel Boost skill for automatic agent integration

### DIFF
--- a/resources/boost/skills/mailbox-for-laravel/SKILL.md
+++ b/resources/boost/skills/mailbox-for-laravel/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: mailbox-for-laravel
+description: Use this skill when working with the redberry/mailbox-for-laravel package — capturing, inspecting, or asserting against outgoing mail in development. Activates when writing tests that use the InteractsWithMailbox trait or Mailbox facade (assertSent, assertSentTo, assertNothingSent, firstSent and per-message assertions like assertHasSubject, assertSeeInHtml, assertHasAttachment); when configuring the mailbox transport in config/mailbox.php; when picking a storage driver (sqlite/database/file) or pairing message and attachment stores; when extending MessageStore or AttachmentStore contracts with a custom driver; when adding routes/middleware behind the viewMailbox gate; when building UI inside the self-contained Vue 3 dashboard under resources/js; when running mailbox:install, mailbox:clear, or mailbox:dev-link; or when troubleshooting captured mail, CID-rewritten inline images, or the dedicated SQLite store at storage/app/mailbox/mailbox.sqlite. Do not use for generic Laravel mail (Mail::send, Mailables) without the mailbox package.
+license: MIT
+metadata:
+  author: redberry
+---
+
+# Mailbox for Laravel
+
+Local in-app inbox that intercepts outgoing mail via a Symfony transport, stores it through pluggable drivers, and serves it via a self-contained Vue 3 dashboard. Zero coupling to the host app's frontend stack.
+
+## When to activate
+
+- Writing tests that capture sent mail via `InteractsWithMailbox` or the `Mailbox` facade
+- Configuring `config/mailbox.php` (driver, path, gate, polling)
+- Using or extending the `mailbox` mail transport
+- Implementing custom `MessageStore` / `AttachmentStore` drivers
+- Touching the dashboard Vue app under `resources/js/`
+- Running package commands: `mailbox:install`, `mailbox:clear`, `mailbox:dev-link`
+
+## Quick reference
+
+### 1. Test assertions → `rules/testing.md`
+
+- Use `InteractsWithMailbox` trait — auto-clears between tests, exposes `$this->mailbox()`
+- Collection-level: `assertSent`, `assertNotSent`, `assertNothingSent`, `assertSentCount`, `assertSentTo`, `assertNotSentTo`, `sent`, `firstSent`
+- Per-message fluent (off `firstSent()`): `assertFrom`, `assertHasTo`, `assertHasSubject`, `assertSeeInHtml`, `assertHasAttachment`, `assertHasHeader`, etc.
+
+### 2. Capture pipeline → `rules/architecture.md`
+
+- `MailboxTransport` → `MessageNormalizer` → `CaptureService` → `MessageStore` driver
+- `CaptureService` is the storage-driver-agnostic entrypoint — store, list, find, update, delete, purge
+- `StoreManager` resolves drivers: `sqlite` (default), `database`, `file`
+- Message and attachment stores are paired — never mix drivers across the pair
+
+### 3. HTTP & authorization → `rules/http.md`
+
+- Routes mounted under `config('mailbox.path', 'mailbox')` with `web` + `mailbox.authorize` middleware
+- Authorization through the `viewMailbox` gate — define your own gate before exposing in production
+- `MailboxController` returns Blade for browser requests, JSON when `$request->wantsJson()` is true
+
+### 4. Conventions → `rules/conventions.md`
+
+- Namespace `Redberry\MailboxForLaravel`
+- No `env()` outside `config/`
+- Constructor injection of interfaces; avoid facades inside core services
+- Vue: `<script setup>`, TypeScript for new files, scoped/prefixed Tailwind classes
+- File IO only through storage drivers
+
+### 5. Things to avoid → `rules/avoid.md`
+
+- Don't bypass the `MessageStore` contract
+- Don't add external services or self-hosted SMTP
+- Don't render unsanitized HTML in the dashboard
+- Don't import from the host app's frontend
+- Don't leave `dd()`, `dump()`, `ray()`, `var_dump()` in committed code
+
+## How to apply
+
+1. Identify the task surface (test, config, driver, dashboard, route) and read the matching rule file.
+2. Check sibling files in the package for the established pattern — match it.
+3. For exact API syntax of installed Laravel/Pest versions, verify with `search-docs`.
+
+## Definition of done
+
+1. Tests added and passing (`composer test`)
+2. PHPStan passes (`composer analyse`)
+3. Pint passes (`composer format`)
+4. No new `env()` outside `config/`
+5. README/CHANGELOG updated for user-facing changes
+6. Conventional Commits format used (`feat:`, `fix:`, `chore:`, `test:`, `refactor:`, `docs:`)

--- a/resources/boost/skills/mailbox-for-laravel/rules/architecture.md
+++ b/resources/boost/skills/mailbox-for-laravel/rules/architecture.md
@@ -1,0 +1,32 @@
+# Architecture
+
+## Mail capture pipeline
+
+```
+MailboxTransport → MessageNormalizer → CaptureService → MessageStore driver
+```
+
+1. **`MailboxTransport`** (`src/Transport/`) — registered as the `mailbox` mail driver. Intercepts sent mail and optionally decorates another transport. Toggleable.
+2. **`MessageNormalizer`** (`src/Support/`) — converts Symfony `Email` / `RawMessage` into a canonical array, extracting attachments as `AttachmentData` DTOs.
+3. **`CaptureService`** (`src/CaptureService.php`) — high-level API: `store`, `list`, `find`, `update`, `delete`, `purge`. Returns `MailboxMessageData` DTOs. Storage-driver-agnostic. Cascades attachment cleanup automatically on `delete`, `clearAll`, `purgeOlderThan`.
+4. **`StoreManager`** (`src/StoreManager.php`) — extends Laravel's `Manager`. Resolves driver: `sqlite` (default), `database`, or `file`.
+5. **Storage drivers** (`src/Storage/`) — `DatabaseMessageStore` (Eloquent, dedicated SQLite at `storage/app/mailbox/mailbox.sqlite`) and `FileStorage` (JSON on disk). Both implement `Contracts\MessageStore`.
+6. **Attachment store pair** — `DatabaseAttachmentStore` or `FileAttachmentStore` is bound alongside the chosen `MessageStore`. Both implement `Contracts\AttachmentStore` and return `StoredAttachment` DTOs. `CidRewriter` resolves inline `cid:` references through the contract regardless of driver.
+
+## Self-contained Vue dashboard
+
+The dashboard is **completely isolated** from the host app:
+
+- The Blade root view (`mailbox::app`) embeds the initial page payload as a `<script type="application/json">` blob.
+- `dashboard.js` parses it, hydrates a shared reactive store, and mounts a plain Vue 3 app.
+- All subsequent interactions (polling, search, pagination, delete) hit the same `MailboxController` — HTML on first load, JSON on AJAX (`$request->wantsJson()`).
+- Own Vite build output at `public/vendor/mailbox/`. Own Vue app instance. Zero host-app coupling.
+
+See `ARCHITECTURE.md` in the repo root for the full deep-dive.
+
+## Extending with a custom driver
+
+1. Implement `Contracts\MessageStore` (9 methods including `idsOlderThan`) and `Contracts\AttachmentStore` (8 methods).
+2. Register the driver via `StoreManager::extend()` inside a service provider.
+3. Add config entry under `config('mailbox.stores')`.
+4. Add unit tests for each contract method and architecture tests for boundary rules.

--- a/resources/boost/skills/mailbox-for-laravel/rules/avoid.md
+++ b/resources/boost/skills/mailbox-for-laravel/rules/avoid.md
@@ -1,0 +1,14 @@
+# Things to Avoid
+
+- **Don't call `env()` outside `config/` files.** Reads outside the config layer break `config:cache`.
+- **Don't use facades in core services** — use interfaces + constructor injection so the package stays test-friendly and Octane-safe.
+- **Don't add external services or self-hosted SMTP.** This package captures locally only.
+- **Don't render raw HTML without sanitization** in the dashboard.
+- **Don't write to arbitrary paths.** Storage drivers constrain paths to the package directory.
+- **Don't bypass the `MessageStore` contract.** All storage goes through `CaptureService`.
+- **Don't add global state or singletons** (except bindings declared in the service provider).
+- **Don't import from the host app's frontend.** The Vue app is fully isolated by design.
+- **Don't hardcode absolute file paths** in package code.
+- **Don't leave `dd()`, `dump()`, `ray()`, or `var_dump()`** in committed code.
+- **Don't mix message and attachment store drivers** across the pair (e.g. `DatabaseMessageStore` with `FileAttachmentStore`).
+- **Don't modify migrations** that have already shipped — add a new migration instead.

--- a/resources/boost/skills/mailbox-for-laravel/rules/conventions.md
+++ b/resources/boost/skills/mailbox-for-laravel/rules/conventions.md
@@ -1,0 +1,39 @@
+# Coding Conventions
+
+## PHP
+
+- **Namespace**: `Redberry\MailboxForLaravel`
+- **No `env()` outside `config/`** — use `config()` everywhere else
+- **Interfaces + constructor injection** — avoid facades in core services
+- **Readonly / immutable** where possible; prefer DTOs and value objects over loose arrays
+- **Stateless services** — transport may store last key but no global singletons (only service-provider bindings)
+- **Throw domain exceptions** for invalid states; no silent failures
+- **File IO via storage drivers only** — never `storage_path()` directly in controllers
+- **No hardcoded absolute paths** in package code
+
+## Vue / Frontend
+
+- `<script setup>` syntax
+- TypeScript for new files
+- Scoped or prefixed Tailwind classes — never leak styles into the host app
+- Components live under `resources/js/`:
+  - `Pages/Dashboard.vue` — main page
+  - `components/mail/` — domain components (list, preview, filters)
+  - `components/ui/` — reusable UI primitives
+  - `composables/` — shared reactive logic
+  - `types/mailbox.ts` — TypeScript interfaces
+
+## Testing policy
+
+- Every new class or feature MUST have tests
+- **Unit** for services, contracts, drivers, DTOs
+- **Feature** for HTTP routes, middleware, commands
+- **Architecture** tests for dependency boundaries (already 26 rules in `tests/Architecture/`)
+- Coverage target: **90%+ lines, 80%+ branches**
+- Pest `describe()` blocks and dataset-driven cases preferred
+
+## Commits & PRs
+
+- **Conventional Commits**: `feat:`, `fix:`, `chore:`, `test:`, `refactor:`, `docs:`
+- README and CHANGELOG updated for user-facing changes
+- `composer format` (Pint), `composer analyse` (PHPStan level 5), `composer test` (Pest) all green before merge

--- a/resources/boost/skills/mailbox-for-laravel/rules/http.md
+++ b/resources/boost/skills/mailbox-for-laravel/rules/http.md
@@ -1,0 +1,49 @@
+# HTTP & Authorization
+
+## Routes
+
+All routes are mounted under `config('mailbox.path', 'mailbox')` with two middleware:
+
+- `web` — session, CSRF, cookie encryption
+- `mailbox.authorize` — wraps the `viewMailbox` gate
+
+Use named routes in tests and views, never hardcoded paths:
+
+```php
+route('mailbox.index')
+route('mailbox.show', $message)
+```
+
+## Authorization
+
+The `viewMailbox` gate ships with a default closure that allows all access in non-production environments. Override it in your `AuthServiceProvider` before exposing the dashboard publicly:
+
+```php
+Gate::define('viewMailbox', function (?User $user) {
+    return $user?->isAdmin() === true;
+});
+```
+
+## Controller responses
+
+`MailboxController` is content-negotiation aware:
+
+- Browser request → returns the Blade view `mailbox::app` with `data` payload
+- `$request->wantsJson()` → returns the same payload as JSON
+
+Tests should assert both shapes:
+
+```php
+// Initial page load
+$this->get(route('mailbox.index'))
+    ->assertViewIs('mailbox::app')
+    ->assertViewHas('data', fn ($data) => /* ... */);
+
+// AJAX
+$this->getJson(route('mailbox.index'))
+    ->assertJsonPath('messages.0.subject', 'Welcome');
+```
+
+## Middleware
+
+`AuthorizeMailboxMiddleware` lives in `src/Http/Middleware/`. It is the only place that consults the gate — controllers should not duplicate the check.

--- a/resources/boost/skills/mailbox-for-laravel/rules/testing.md
+++ b/resources/boost/skills/mailbox-for-laravel/rules/testing.md
@@ -1,0 +1,75 @@
+# Testing with Mailbox for Laravel
+
+Mailbox provides Laravel-idiomatic assertion helpers for verifying captured emails. Works with both Pest and PHPUnit.
+
+## Setup
+
+Add the trait to your test class (or use it in a Pest `beforeEach`):
+
+```php
+use Redberry\MailboxForLaravel\Testing\InteractsWithMailbox;
+
+uses(InteractsWithMailbox::class);
+```
+
+The trait auto-clears the mailbox between tests and exposes `$this->mailbox()` for collection-level assertions.
+
+## Collection-level assertions
+
+Available via `$this->mailbox()` or the `Mailbox` facade:
+
+- `assertSent(Closure $callback, ?int $expectedCount = null)`
+- `assertNotSent(Closure $callback)`
+- `assertNothingSent()`
+- `assertSentCount(int $count)`
+- `assertSentTo(string $email, ?Closure $callback = null)`
+- `assertNotSentTo(string $email, ?Closure $callback = null)`
+- `sent(?Closure $callback = null): Collection` — raw query, no assertion
+- `firstSent(?Closure $callback = null): PendingMailboxMessageAssertion` — chain into per-message assertions
+
+## Per-message fluent assertions
+
+Chain off `firstSent()`:
+
+**Recipients & headers**
+
+- `assertFrom`, `assertHasTo`, `assertHasCc`, `assertHasBcc`, `assertHasReplyTo`
+- `assertHasHeader`
+
+**Subject**
+
+- `assertHasSubject`, `assertSubjectContains`
+
+**Body content**
+
+- `assertSeeInHtml`, `assertDontSeeInHtml`
+- `assertSeeInText`, `assertDontSeeInText`
+- `assertSeeInOrderInHtml`, `assertSeeInOrderInText`
+
+**Attachments**
+
+- `assertHasAttachment`, `assertHasNoAttachments`, `assertAttachmentCount`
+
+## Example
+
+```php
+use Redberry\MailboxForLaravel\Facades\Mailbox;
+
+it('sends the welcome email', function () {
+    Mail::to('user@example.com')->send(new WelcomeMail);
+
+    Mailbox::assertSentTo('user@example.com');
+
+    $this->mailbox()
+        ->firstSent()
+        ->assertHasSubject('Welcome')
+        ->assertSeeInHtml('Get started')
+        ->assertHasAttachment('terms.pdf');
+});
+```
+
+## Notes
+
+- For queued mailables, prefer Laravel's `Mail::assertQueued()` — Mailbox captures only what actually goes through the transport.
+- Run a single test: `vendor/bin/pest --filter="sends the welcome email"`.
+- Run the package's own test suite: `composer test` (or `bin/check` for Pint + PHPStan + Pest).


### PR DESCRIPTION
## Summary

Adds a Laravel Boost skill at `resources/boost/skills/mailbox-for-laravel/` so any project consuming this package automatically picks it up when running `php artisan boost:install`.

Boost discovers third-party skills by scanning every Composer-installed package for `resources/boost/skills/<skill-name>/SKILL.md` ([SkillComposer.php#L96](https://github.com/laravel/boost/blob/main/src/Install/SkillComposer.php#L96), [Composer.php#L77](https://github.com/laravel/boost/blob/main/src/Support/Composer.php#L77)). Once discovered, Boost wires the skill into the agent's skill folder (`.claude/skills/`, `.cursor/skills/`, etc.) — no service-provider hook, no registration code, just the file path.

The skill content is condensed from the existing `CLAUDE.md` and split into a top-level `SKILL.md` plus a `rules/` subfolder, mirroring the layout used by `laravel/boost`'s own `laravel-best-practices` skill.

## What's included

- `SKILL.md` — YAML frontmatter (`name`, `description`, license, author) + quick-reference index
- `rules/testing.md` — `InteractsWithMailbox` trait + collection-level and per-message assertion catalogue
- `rules/architecture.md` — capture pipeline, dashboard isolation, custom-driver guidance
- `rules/http.md` — routes, `viewMailbox` gate, controller content negotiation
- `rules/conventions.md` — PHP, Vue, testing policy, Conventional Commits
- `rules/avoid.md` — the existing "Don't" list

## How to verify locally

In any Laravel app that requires `redberry/mailbox-for-laravel` from this branch:

```bash
composer require redberry/mailbox-for-laravel:dev-feat/boost-skill
php artisan boost:install
```

Confirm the `mailbox-for-laravel` skill appears under `.claude/skills/` (or whichever agent was selected during install), with the description from `SKILL.md`.

## Test plan

- [ ] `composer test` still green (no package code changed, but worth confirming)
- [ ] `composer analyse` (PHPStan) still green
- [ ] `composer format` (Pint) still green
- [ ] Install package in a fresh Laravel app, run `php artisan boost:install`, confirm skill is wired into the agent folder

## Notes

- No package code, tests, or runtime behavior changed — this is documentation that ships alongside the package.
- The `description` in `SKILL.md` is intentionally trigger-rich (mentions `assertSent`, `InteractsWithMailbox`, `config/mailbox.php`, `viewMailbox`, etc.) so agents activate the skill on the right surface.
- License set to MIT to match the package; `metadata.author` set to `redberry`.