### PR TITLE
docs: add About Redberry section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,10 @@ If you discover a security vulnerability within this package, please email **sec
 - [Redberry](https://redberry.international)
 - [All contributors](https://github.com/RedberryProducts/mailbox-for-laravel/graphs/contributors)
 
+## About Redberry
+
+This package is built and maintained by [Redberry](https://redberry.international/?utm_source=github&utm_medium=github_mailbox_readme&utm_campaign=laravel_service_campaign), one of the few Official Premier Laravel Partner agencies worldwide. With 250+ Laravel projects shipped across 20+ countries, a 200-person team, and over a decade in the Laravel ecosystem, Redberry has helped startups, SMEs, and publicly traded enterprises in regulated industries build SaaS platforms, custom web applications, APIs, and more. [Learn about our Laravel development services](https://redberry.international/laravel-development/?utm_source=github&utm_medium=github_mailbox_readme&utm_campaign=laravel_service_campaign).
+
 ## License
 
 The MIT License (MIT). See [LICENSE.md](LICENSE.md).


### PR DESCRIPTION
Adds the marketing-supplied **About Redberry** section to the README, between Credits and License. Previously the README only had a bare `[Redberry](https://redberry.international)` link in Credits with no accompanying text.

Copy is verbatim from marketing. Links:
- Redberry → `https://redberry.international/`
- Learn about our Laravel development services → `https://redberry.international/laravel-development/`

Both carry `utm_source=github&utm_medium=github_mailbox_readme&utm_campaign=laravel_service_campaign` (mirrors the convention already used in mcp-client-laravel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6xyqEjTHSqz2CkQM1DDn2