### PR TITLE
fix: drop payload keys with no column, and declare model properties

### DIFF
--- a/src/Models/MailboxMessage.php
+++ b/src/Models/MailboxMessage.php
@@ -5,8 +5,35 @@ namespace Redberry\MailboxForLaravel\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
 use Redberry\MailboxForLaravel\Database\Factories\MailboxMessageFactory;
 
+/**
+ * The table name is resolved from config at runtime, so static analysis cannot
+ * read the columns off the migration. They are declared here instead.
+ *
+ * @property string $id
+ * @property int $timestamp
+ * @property Carbon|null $seen_at
+ * @property int $version
+ * @property Carbon|null $saved_at
+ * @property string|null $message_id
+ * @property string|null $subject
+ * @property Carbon|null $date
+ * @property array<string, mixed>|null $from
+ * @property array<string, mixed>|null $sender
+ * @property array<int, mixed>|null $to
+ * @property array<int, mixed>|null $cc
+ * @property array<int, mixed>|null $bcc
+ * @property array<int, mixed>|null $reply_to
+ * @property string|null $text
+ * @property string|null $html
+ * @property array<string, mixed>|null $headers
+ * @property array<int, mixed>|null $attachments
+ * @property string|null $raw
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
 class MailboxMessage extends Model
 {
     use HasFactory;

--- a/src/Storage/DatabaseMessageStore.php
+++ b/src/Storage/DatabaseMessageStore.php
@@ -20,6 +20,36 @@ use Redberry\MailboxForLaravel\Search\DefaultMessageSearch;
  */
 class DatabaseMessageStore implements MessageStore
 {
+    /**
+     * Payload keys this driver can persist, i.e. the writable columns on the
+     * messages table. The payload contract is an open map — the file driver
+     * keeps it verbatim as JSON — but here it has to land on a fixed schema,
+     * so anything outside this list is dropped instead of being handed to the
+     * query builder as an unknown column.
+     *
+     * `id` is absent on purpose: it is passed as the match attribute.
+     */
+    private const COLUMNS = [
+        'timestamp',
+        'seen_at',
+        'version',
+        'saved_at',
+        'message_id',
+        'subject',
+        'date',
+        'from',
+        'sender',
+        'to',
+        'cc',
+        'bcc',
+        'reply_to',
+        'text',
+        'html',
+        'headers',
+        'attachments',
+        'raw',
+    ];
+
     public function __construct(
         private readonly MessageSearch $search = new DefaultMessageSearch,
     ) {}
@@ -37,7 +67,7 @@ class DatabaseMessageStore implements MessageStore
 
         MailboxMessage::query()->updateOrCreate(
             ['id' => $id],
-            $payload,
+            array_intersect_key($payload, array_flip(self::COLUMNS)),
         );
 
         return $id;

--- a/tests/Unit/DatabaseMessageStoreTest.php
+++ b/tests/Unit/DatabaseMessageStoreTest.php
@@ -156,6 +156,25 @@ describe(DatabaseMessageStore::class, function () {
         expect($store->findIdByMessageId('<unknown@example.com>'))->toBeNull();
     });
 
+    it('drops payload keys that have no column instead of failing the insert', function () {
+        $store = new DatabaseMessageStore;
+        $id = ulid();
+
+        $returned = $store->store([
+            'id' => $id,
+            'raw' => 'email content',
+            'timestamp' => time(),
+            'subject' => 'Test',
+            'not_a_column' => 'dropped',
+        ]);
+
+        $result = $store->find($returned);
+
+        expect($result)->not->toHaveKey('not_a_column')
+            ->and($result['subject'])->toBe('Test')
+            ->and($result['raw'])->toBe('email content');
+    });
+
     it('handles updateOrCreate when storing with existing id', function () {
         $store = new DatabaseMessageStore;
         $existingId = $store->store([


### PR DESCRIPTION
Makes phpstan green. It has been red on `main` since before v2.2.1 (also red on the v2.2.1 and v2.3.0 tags) with a single error:

```
src/Storage/DatabaseMessageStore.php:40
Parameter #2 $values of method Builder<MailboxMessage>::updateOrCreate()
expects array<model property of MailboxMessage, mixed>|Closure,
non-empty-array<string, mixed> given.
```

## Two causes

**1. larastan could not see the model's columns at all.** `MailboxMessage` had no `@property` annotations, and its table name comes from `config()` at runtime (both in the migration and in `getTable()`), so there is nothing static tying the columns to the model. With `checkModelProperties: true` it rejected *every* column name — the first attempt at a fix, passing a literal-keyed array, produced 17 "should be a property of MailboxMessage" tips, one per column. Declared them on the model, which is what `MailboxAttachment` already does.

**2. The database driver passed the payload through untouched.** The payload is an open map by contract — *"drivers must persist it verbatim"* — and the file driver does keep it as JSON. This driver has to land it on a fixed schema, so any key without a column went straight to the query builder:

```
SQLSTATE[HY000]: General error: 1 table mailbox_messages has no column named not_a_column
```

So the phpstan error was flagging a real latent bug, not just a typing gap. `store()` now intersects the payload with the writable columns, which is both what makes the array statically checkable and what stops that insert from failing. `id` is deliberately excluded from the list — it is the match attribute.

Added a test for it; it fails with a `QueryException` if the intersect is removed.

## Verification

| | |
|---|---|
| `phpstan analyse` | **[OK] No errors** (was 1) |
| `composer test` | 347 passed, 807 assertions (was 346) |
| `pint --test` | passed |

No `@phpstan-ignore`, no baseline entry, no inline `@var`, no cast.

## Note

`phpstan analyse` needs `--memory-limit` raised locally if your php.ini default is 128M — the worker crashes before it reports anything. CI is unaffected: `shivammathur/setup-php` sets `memory_limit=-1`, and the workflow runs plain `./vendor/bin/phpstan`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6xyqEjTHSqz2CkQM1DDn2
